### PR TITLE
External launcher enabling multi VLLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ from trl import GRPOTrainer
 
 dataset = load_dataset("trl-lib/tldr", split="train")
 
-# Dummy reward function: count the number of unique caracteres in the completions
+# Dummy reward function: count the number of unique characters in the completions
 def reward_num_unique_chars(completions, **kwargs):
     return [len(set(c)) for c in completions]
 

--- a/docs/source/reducing_memory_usage.md
+++ b/docs/source/reducing_memory_usage.md
@@ -94,6 +94,41 @@ Packing may cause batch contamination, where adjacent sequences influence one an
 
 </Tip>
 
+## Padding-free
+
+Padding-free batching is an alternative approach for reducing memory usage. In this method, a batch is first sampled and then flattened into a single sequence, avoiding padding. Unlike packing, which can result in incomplete sequences by combining parts of different samples, padding-free batching ensures that all sequences remain complete and intact.
+
+<div class="flex justify-center">
+    <img src="https://huggingface.co/datasets/trl-lib/documentation-images/resolve/main/padding-free.png" alt="Padding-free batching" width="600"/>
+</div>
+
+<Tip warning={true}>
+
+It's highly recommended to use padding-free batching with **Flash Attention 2**. Otherwise, you may encounter batch contamination issues.
+
+</Tip>
+
+<hfoptions id="padding-free">
+<hfoption id="DPO">
+
+```python
+from trl import DPOConfig
+
+training_args = DPOConfig(..., padding_free=True, model_init_kwargs={"attn_implementation": "flash_attention2"})
+```
+
+</hfoption>
+<hfoption id="SFT">
+
+```python
+from trl import SFTConfig
+
+training_args = SFTConfig(..., padding_free=True, model_init_kwargs={"attn_implementation": "flash_attention2"})
+```
+
+</hfoption>
+</hfoptions>
+
 ## Disabling model gathering for generation in online methods
 
 When using DeepSpeed ZeRO-3, model weights are sharded across multiple GPUs. Online methods involve generating completions from the model as part of the training process. During this step, the model weights are temporarily gathered on a single GPU for generation. For very large models, this gathering can lead to out-of-memory (OOM) errors, as described in this issue: [#2250](https://github.com/huggingface/trl/issues/2250#issue-2598304204).

--- a/examples/scripts/sft_gemma3.py
+++ b/examples/scripts/sft_gemma3.py
@@ -1,0 +1,62 @@
+# Copyright 2025 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Train Gemma-3 on the Codeforces COTS dataset.
+
+accelerate launch --config_file examples/accelerate_configs/deepspeed_zero3.yaml examples/scripts/sft_gemma3.py
+"""
+
+from datasets import load_dataset
+from transformers import AutoModelForImageTextToText
+
+from trl import SFTConfig, SFTTrainer
+
+
+def main():
+    # Load dataset
+    train_dataset = load_dataset("open-r1/codeforces-cots", split="train")
+    train_dataset = train_dataset.remove_columns("prompt")
+
+    # Load model
+    model_id = "google/gemma-3-12b-it"
+    model = AutoModelForImageTextToText.from_pretrained(model_id, attn_implementation="eager")
+
+    # Train model
+    training_args = SFTConfig(
+        output_dir=f"{model_id}-codeforces-SFT",
+        logging_steps=10,
+        bf16=True,
+        use_liger_kernel=True,
+        gradient_checkpointing=True,
+        gradient_checkpointing_kwargs={"use_reentrant": False},
+        max_length=8192,
+        per_device_train_batch_size=1,
+        gradient_accumulation_steps=8,
+        dataset_num_proc=32,
+        num_train_epochs=1,
+    )
+    trainer = SFTTrainer(
+        args=training_args,
+        model=model,
+        train_dataset=train_dataset,
+    )
+    trainer.train()
+
+    # Push to hub
+    trainer.push_to_hub(dataset_name="open-r1/codeforces-cots")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_gkd_trainer.py
+++ b/tests/test_gkd_trainer.py
@@ -147,14 +147,14 @@ class TestGeneralizedJSDLoss(unittest.TestCase):
         # Case 1: beta = 1 (should be equivalent to KL(student || teacher))
         loss_beta_1 = GKDTrainer.generalized_jsd_loss(student_logits, teacher_logits, beta=1)
         expected_loss_beta_1 = F.kl_div(
-            F.log_softmax(student_logits, dim=-1), F.softmax(teacher_logits, dim=-1), reduction="batchmean"
+            F.log_softmax(teacher_logits, dim=-1), F.softmax(student_logits, dim=-1), reduction="batchmean"
         )
         self.assertAlmostEqual(loss_beta_1.item(), expected_loss_beta_1.item(), places=5)
 
         # Case 2: beta = 0 (should be equivalent to KL(teacher || student))
         loss_beta_0 = GKDTrainer.generalized_jsd_loss(student_logits, teacher_logits, beta=0)
         expected_loss_beta_0 = F.kl_div(
-            F.log_softmax(teacher_logits, dim=-1), F.softmax(student_logits, dim=-1), reduction="batchmean"
+            F.log_softmax(student_logits, dim=-1), F.softmax(teacher_logits, dim=-1), reduction="batchmean"
         )
         self.assertAlmostEqual(loss_beta_0.item(), expected_loss_beta_0.item(), places=5)
 

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -1100,7 +1100,7 @@ class SFTTrainerTester(unittest.TestCase):
                 eval_dataset=self.conversational_lm_dataset["test"],
             )
 
-            self.assertEqual(len(trainer.train_dataset["input_ids"]), 46)  # w/ this dataset, we end up with 46 seqs
+            self.assertEqual(len(trainer.train_dataset["input_ids"]), 47)  # w/ this dataset, we end up with 46 seqs
             self.assertEqual(len(trainer.eval_dataset["input_ids"]), len(self.conversational_lm_dataset["test"]))
 
     def test_sft_trainer_eval_packing(self):
@@ -1125,8 +1125,8 @@ class SFTTrainerTester(unittest.TestCase):
                 eval_dataset=self.conversational_lm_dataset["test"],
             )
 
-            self.assertEqual(len(trainer.train_dataset["input_ids"]), 46)  # w/ this dataset, we end up with 46 seqs
-            self.assertEqual(len(trainer.eval_dataset["input_ids"]), 6)  # w/ this dataset, we end up with 6 seqs
+            self.assertEqual(len(trainer.train_dataset["input_ids"]), 47)  # w/ this dataset, we end up with 47 seqs
+            self.assertEqual(len(trainer.eval_dataset["input_ids"]), 7)  # w/ this dataset, we end up with 7 seqs
 
     def test_sft_trainer_no_packing(self):
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -28,7 +28,7 @@ from transformers import (
     TrainingArguments,
     is_vision_available,
 )
-from transformers.testing_utils import require_peft, require_vision
+from transformers.testing_utils import require_flash_attn, require_peft, require_vision
 from transformers.utils import is_peft_available
 
 from trl import SFTConfig, SFTTrainer
@@ -1458,7 +1458,7 @@ class SFTTrainerTester2(unittest.TestCase):
                 new_param = trainer.model.get_parameter(n)
                 self.assertFalse(torch.allclose(param, new_param), f"Parameter {n} has not changed")
 
-    def test_train_with_padding_free(self):
+    def test_train_with_data_collator_for_completion_only_and_padding_free(self):
         # Get the dataset
         model_id = "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
         dataset = load_dataset("trl-internal-testing/zen", "conversational_prompt_completion", split="train")
@@ -1471,6 +1471,38 @@ class SFTTrainerTester2(unittest.TestCase):
             # Initialize the trainer
             training_args = SFTConfig(output_dir=tmp_dir, report_to="none")
             trainer = SFTTrainer(model=model_id, args=training_args, train_dataset=dataset, data_collator=collator)
+
+            # Save the initial parameters to compare them later
+            previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}
+
+            # Train the model
+            trainer.train()
+
+            # Check that the training loss is not None
+            self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
+
+            # Check the params have changed
+            for n, param in previous_trainable_params.items():
+                new_param = trainer.model.get_parameter(n)
+                self.assertFalse(torch.allclose(param, new_param), f"Parameter {n} has not changed")
+
+    @require_flash_attn
+    def test_train_padding_free(self):
+        # Get the dataset
+        dataset = load_dataset("trl-internal-testing/zen", "standard_language_modeling", split="train")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            # Initialize the trainer
+            training_args = SFTConfig(
+                output_dir=tmp_dir,
+                padding_free=True,
+                model_init_kwargs={"attn_implementation": "flash_attention_2"},
+                bf16=True,  # flash_attention_2 only supports bf16 and fp16
+                report_to="none",
+            )
+            trainer = SFTTrainer(
+                model="trl-internal-testing/tiny-Qwen2ForCausalLM-2.5", args=training_args, train_dataset=dataset
+            )
 
             # Save the initial parameters to compare them later
             previous_trainable_params = {n: param.clone() for n, param in trainer.model.named_parameters()}

--- a/trl/models/__init__.py
+++ b/trl/models/__init__.py
@@ -20,7 +20,13 @@ from ..import_utils import OptionalDependencyNotAvailable, _LazyModule, is_diffu
 _import_structure = {
     "modeling_base": ["GeometricMixtureWrapper", "PreTrainedModelWrapper", "create_reference_model"],
     "modeling_value_head": ["AutoModelForCausalLMWithValueHead", "AutoModelForSeq2SeqLMWithValueHead"],
-    "utils": ["SUPPORTED_ARCHITECTURES", "prepare_deepspeed", "setup_chat_format", "unwrap_model_for_generation"],
+    "utils": [
+        "SUPPORTED_ARCHITECTURES",
+        "prepare_deepspeed",
+        "prepare_fsdp",
+        "setup_chat_format",
+        "unwrap_model_for_generation",
+    ],
 }
 
 try:
@@ -39,7 +45,13 @@ else:
 if TYPE_CHECKING:
     from .modeling_base import GeometricMixtureWrapper, PreTrainedModelWrapper, create_reference_model
     from .modeling_value_head import AutoModelForCausalLMWithValueHead, AutoModelForSeq2SeqLMWithValueHead
-    from .utils import SUPPORTED_ARCHITECTURES, prepare_deepspeed, setup_chat_format, unwrap_model_for_generation
+    from .utils import (
+        SUPPORTED_ARCHITECTURES,
+        prepare_deepspeed,
+        prepare_fsdp,
+        setup_chat_format,
+        unwrap_model_for_generation,
+    )
 
     try:
         if not is_diffusers_available():

--- a/trl/scripts/sft.py
+++ b/trl/scripts/sft.py
@@ -52,7 +52,8 @@ python trl/scripts/sft.py \
 import argparse
 
 from datasets import load_dataset
-from transformers import AutoTokenizer
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
+from transformers.models.auto.modeling_auto import MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES
 
 from trl import (
     ModelConfig,
@@ -80,7 +81,20 @@ def main(script_args, training_args, model_args):
         device_map=get_kbit_device_map() if quantization_config is not None else None,
         quantization_config=quantization_config,
     )
-    training_args.model_init_kwargs = model_kwargs
+
+    # Create model
+    config = AutoConfig.from_pretrained(model_args.model_name_or_path)
+    valid_image_text_architectures = MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES.values()
+
+    if config.architectures and any(arch in valid_image_text_architectures for arch in config.architectures):
+        from transformers import AutoModelForImageTextToText
+
+        model_kwargs.pop("use_cache", None)  # Image models do not support cache
+        model = AutoModelForImageTextToText.from_pretrained(model_args.model_name_or_path, **model_kwargs)
+    else:
+        model = AutoModelForCausalLM.from_pretrained(model_args.model_name_or_path, **model_kwargs)
+
+    # Create tokenizer
     tokenizer = AutoTokenizer.from_pretrained(
         model_args.model_name_or_path, trust_remote_code=model_args.trust_remote_code, use_fast=True
     )
@@ -96,7 +110,7 @@ def main(script_args, training_args, model_args):
     # Training
     ################
     trainer = SFTTrainer(
-        model=model_args.model_name_or_path,
+        model=model,
         args=training_args,
         train_dataset=dataset[script_args.dataset_train_split],
         eval_dataset=dataset[script_args.dataset_test_split] if training_args.eval_strategy != "no" else None,

--- a/trl/trainer/dpo_config.py
+++ b/trl/trainer/dpo_config.py
@@ -81,10 +81,10 @@ class DPOConfig(TrainingArguments):
             Truncation mode to use when the sequence exceeds `max_length`. Possible values are `"keep_end"` and
             `"keep_start"`.
         padding_free (`bool`, *optional*, defaults to `False`):
-            Whether forward passes are performed without padding by flattening all sequences in the batch
-            into a single continuous sequence. This approach requires associating a `position_ids` vector to track
-            positional information. Currently, this is only supported with the `flash_attention_2` mechanism, as it
-            can handle the flattened batch structure.
+            Whether to perform forward passes without padding by flattening all sequences in the batch into a single
+            continuous sequence. This reduces memory usage by eliminating padding overhead. Currently, this is only
+            supported with the `flash_attention_2` attention implementation, which can efficiently handle the flattened
+            batch structure.
         precompute_ref_log_probs (`bool`, *optional*, defaults to `False`):
             Whether to precompute the log probabilities from the reference model. Setting this to `True` allows
             training without needing the reference model during training, which can help reduce GPU memory usage. If
@@ -243,10 +243,10 @@ class DPOConfig(TrainingArguments):
     padding_free: bool = field(
         default=False,
         metadata={
-            "help": "Whether forward passes are performed without padding by flattening all sequences in the batch "
-            "into a single continuous sequence. This approach requires associating a `position_ids` vector to track "
-            "positional information. Currently, this is only supported with the `flash_attention_2` mechanism, as it "
-            "can handle the flattened batch structure."
+            "help": "Whether to perform forward passes without padding by flattening all sequences in the batch into "
+            "a single continuous sequence. This reduces memory usage by eliminating padding overhead. Currently, "
+            "this is only supported with the `flash_attention_2` attention implementation, which can efficiently "
+            "handle the flattened batch structure."
         },
     )
     precompute_ref_log_probs: bool = field(

--- a/trl/trainer/dpo_trainer.py
+++ b/trl/trainer/dpo_trainer.py
@@ -54,6 +54,7 @@ from transformers.utils import is_peft_available, is_torch_xpu_available
 
 from ..data_utils import maybe_apply_chat_template, maybe_extract_prompt
 from ..models import PreTrainedModelWrapper, create_reference_model
+from ..models.utils import prepare_fsdp
 from .callbacks import SyncRefModelCallback
 from .dpo_config import DPOConfig, FDivergenceConstants, FDivergenceType
 from .utils import (
@@ -510,6 +511,8 @@ class DPOTrainer(Trainer):
         else:
             if self.is_deepspeed_enabled:
                 self.ref_model = self._prepare_deepspeed(self.ref_model)
+            elif self.is_fsdp_enabled:
+                self.ref_model = prepare_fsdp(self.ref_model, self.accelerator)
             else:
                 self.ref_model = self.accelerator.prepare_model(self.ref_model, evaluation_mode=True)
 

--- a/trl/trainer/gkd_trainer.py
+++ b/trl/trainer/gkd_trainer.py
@@ -187,21 +187,26 @@ class GKDTrainer(SFTTrainer):
         student_log_probs = F.log_softmax(student_logits, dim=-1)
         teacher_log_probs = F.log_softmax(teacher_logits, dim=-1)
 
-        # Compute the log of the mixture distribution
-        # log(a + b) = log(exp(log(a)) + exp(log(b))) -> for mixture
-        beta = torch.tensor(beta, dtype=student_log_probs.dtype)
-        mixture_log_probs = torch.logsumexp(
-            torch.stack([student_log_probs + torch.log(beta), teacher_log_probs + torch.log(1 - beta)]),
-            dim=0,
-        )
+        if beta == 0:
+            jsd = F.kl_div(student_log_probs, teacher_log_probs, reduction="none", log_target=True)
+        elif beta == 1:
+            jsd = F.kl_div(teacher_log_probs, student_log_probs, reduction="none", log_target=True)
+        else:
+            # Compute the log of the mixture distribution
+            # log(a + b) = log(exp(log(a)) + exp(log(b))) -> for mixture
+            beta = torch.tensor(beta, dtype=student_log_probs.dtype)
+            mixture_log_probs = torch.logsumexp(
+                torch.stack([student_log_probs + torch.log(1 - beta), teacher_log_probs + torch.log(beta)]),
+                dim=0,
+            )
 
-        # Compute KL divergences using F.kl_div
-        # PyTorch differs from the standard mathematical definition, so the order of the probability distributions is swapped compared to that defined in the paper.
-        kl_teacher = F.kl_div(mixture_log_probs, teacher_log_probs, reduction="none", log_target=True)
-        kl_student = F.kl_div(mixture_log_probs, student_log_probs, reduction="none", log_target=True)
+            # Compute KL divergences using F.kl_div
+            # PyTorch differs from the standard mathematical definition, so the order of the probability distributions is swapped compared to that defined in the paper.
+            kl_teacher = F.kl_div(mixture_log_probs, teacher_log_probs, reduction="none", log_target=True)
+            kl_student = F.kl_div(mixture_log_probs, student_log_probs, reduction="none", log_target=True)
 
-        # Compute the Generalized Jensen-Shannon Divergence
-        jsd = beta * kl_teacher + (1 - beta) * kl_student
+            # Compute the Generalized Jensen-Shannon Divergence
+            jsd = beta * kl_teacher + (1 - beta) * kl_student
 
         # Masking
         if labels is not None:

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -72,6 +72,8 @@ class GRPOConfig(TrainingArguments):
             Float that penalizes new tokens based on whether they appear in the prompt and the generated text so far.
             Values > `1.0` encourage the model to use new tokens, while values < `1.0` encourage the model to repeat
             tokens.
+        cache_implementation (`str` or `None`, *optional*, defaults to `None`):
+            Implementation of the cache method for faster generation when use_vllm is set to False.
 
         > Parameters that control generation acceleration powered by vLLM
 
@@ -216,6 +218,10 @@ class GRPOConfig(TrainingArguments):
             "text so far. Values > 1.0 encourage the model to use new tokens, while values < 1.0 encourage the model "
             "to repeat tokens."
         },
+    )
+    cache_implementation: Optional[str] = field(
+        default=None,
+        metadata={"help": "Implementation of the cache method for faster generation when use_vllm is set to False."},
     )
 
     # Parameters that control generation acceleration powered by vLLM

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -102,6 +102,10 @@ class GRPOConfig(TrainingArguments):
             support this feature.
         vllm_guided_decoding_regex (`str` or `None`, *optional*, defaults to `None`):
             Regex for vLLM guided decoding. If `None` (default), guided decoding is disabled.
+        vllm_external_launcher (`bool`, *optional*, defaults to `False`):
+            Whether to use an external launcher for distributed vLLM execution. If set to `True`, vLLM will be 
+            initialized in **all processes**, each assigned to its respective device. This allows multi-GPU 
+            or multi-node execution with vLLM's external launcher, enabling improved large-scale inference.
 
         > Parameters that control the training
 
@@ -275,6 +279,14 @@ class GRPOConfig(TrainingArguments):
     vllm_guided_decoding_regex: Optional[str] = field(
         default=None,
         metadata={"help": "Regex for vLLM guided decoding. If `None` (default), guided decoding is disabled."},
+    )
+    vllm_external_launcher: Optional[bool] = field(
+        default=False,
+        metadata={
+            "help": "Whether to use an external launcher for distributed vLLM execution. If set to `True`, vLLM will be "
+                    "initialized in all processes, each assigned to its respective device. This enables optimized "
+                    "multi-GPU or multi-node inference."
+        },
     )
 
     # Parameters that control the training

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -548,6 +548,7 @@ class GRPOTrainer(Trainer):
                 top_k=args.top_k,
                 min_p=args.min_p,
                 repetition_penalty=args.repetition_penalty,
+                cache_implementation=args.cache_implementation,
             )
 
         # Gradient accumulation requires scaled loss. Normally, loss scaling in the parent class depends on whether the

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -506,6 +506,9 @@ class GRPOTrainer(Trainer):
                         device=vllm_device,
                         gpu_memory_utilization=self.args.vllm_gpu_memory_utilization,
                         dtype=self.args.vllm_dtype,
+                        # Automatic Prefix Caching caches the KV cache of existing queries, so that a new query can
+                        # directly reuse the KV cache if it shares the same prefix with one of the existing queries.
+                        # This is particularly useful here because we generate completions from the same prompts.
                         enable_prefix_caching=self.args.vllm_enable_prefix_caching,
                         max_model_len=self.args.vllm_max_model_len,
                         distributed_executor_backend="external_launcher" if self.args.vllm_external_launcher else None,

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -59,10 +59,10 @@ from .utils import (
     selective_log_softmax,
 )
 
-import debugpy
-debugpy.listen(("0.0.0.0", 5679))  # Allow remote debugging
-print("\n\n\n\n-=-=-=-=-=-Waiting for debugger to attach...\n\n\n\n\n")
-debugpy.wait_for_client()  # Execution will pause here until a debugger is attached
+# import debugpy
+# debugpy.listen(("0.0.0.0", 5679))  # Allow remote debugging
+# print("\n\n\n\n-=-=-=-=-=-Waiting for debugger to attach...\n\n\n\n\n")
+# debugpy.wait_for_client()  # Execution will pause here until a debugger is attached
 
 if is_peft_available():
     from peft import PeftConfig, get_peft_model
@@ -848,11 +848,15 @@ class GRPOTrainer(Trainer):
                     # Since 'prompts' contains 'num_generations' duplicates, we first take unique prompts, and generate
                     # num_generations outputs for each one. This is faster than generating outputs for each duplicate
                     # prompt individually.
+                    print("In the main process, let's check all prompts size")
+                    print("all_prompts_text", len(all_prompts_text))
+                    print("ordered size: ", len(ordered_set_of_prompts))
                     ordered_set_of_prompts = all_prompts_text[:: self.num_generations]
                     with profiling_context(self, "vLLM.generate"):
                         all_outputs = self.llm.generate(
                             ordered_set_of_prompts, sampling_params=self.sampling_params, use_tqdm=False
                         )
+                    print("all_outputs size: ", len(all_outputs))
                     completion_ids = []
                     for outputs in all_outputs:
                         for output in outputs.outputs:

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -481,9 +481,8 @@ class GRPOTrainer(Trainer):
                             "`vllm_gpu_memory_utilization` accordingly."
                         )
 
-                # Prepare a list of context managers
+                # Prepare a list of context managers according to device type and vllm w/o external launcher
                 cmanagers = []
-
                 if not self.args.vllm_external_launcher:
                     cmanagers.extend([
                         functools.partial(patch, "torch.distributed.get_world_size", return_value=1),
@@ -501,7 +500,7 @@ class GRPOTrainer(Trainer):
                     for cm in cmanagers:
                         stack.enter_context(cm())
 
-                    # Initialize the LLM
+                    # Initialize the LLM (set distributed_executor_backend = external_launcher if requested)
                     self.llm = LLM(
                         model=model.name_or_path,
                         device=vllm_device,

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -59,6 +59,10 @@ from .utils import (
     selective_log_softmax,
 )
 
+import debugpy
+debugpy.listen(("0.0.0.0", 5679))  # Allow remote debugging
+print("\n\n\n\n-=-=-=-=-=-Waiting for debugger to attach...\n\n\n\n\n")
+debugpy.wait_for_client()  # Execution will pause here until a debugger is attached
 
 if is_peft_available():
     from peft import PeftConfig, get_peft_model

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -822,7 +822,8 @@ class GRPOTrainer(Trainer):
                 completion_ids = [None] * len(all_prompts_text)
 
             if not self.args.vllm_external_launcher:
-                # Broadcast completions to all processes
+                # Broadcast the completions from the main process to all processes, ensuring each process receives its
+                # corresponding slice.
                 completion_ids = broadcast_object_list(completion_ids, from_process=0)
                 process_slice = slice(
                     self.accelerator.process_index * len(prompts),

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -850,8 +850,9 @@ class GRPOTrainer(Trainer):
                     # prompt individually.
                     print("In the main process, let's check all prompts size")
                     print("all_prompts_text", len(all_prompts_text))
-                    print("ordered size: ", len(ordered_set_of_prompts))
+                    
                     ordered_set_of_prompts = all_prompts_text[:: self.num_generations]
+                    print("ordered size: ", len(ordered_set_of_prompts))
                     with profiling_context(self, "vLLM.generate"):
                         all_outputs = self.llm.generate(
                             ordered_set_of_prompts, sampling_params=self.sampling_params, use_tqdm=False

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -458,7 +458,9 @@ class GRPOTrainer(Trainer):
                 if self.args.vllm_external_launcher:
                     # External launcher mode: Assign vLLM to the current process's device
                     vllm_device = f"{device_type}:{self.accelerator.process_index}"  
+                    print("---- Using external launcher - multi vllm")
                 else:
+                    print("---- Using single vllm")
                     vllm_device = self.args.vllm_device
                     if vllm_device == "auto":
                         # if self.args.vllm_external_launcher --> current device
@@ -736,8 +738,10 @@ class GRPOTrainer(Trainer):
 
             if self.args.vllm_external_launcher or self.accelerator.is_main_process:
                 if self.args.vllm_external_launcher:
+                    print("-- External launcher - work your own batch")
                     prompts_to_use = prompts_text  # Each GPU handles its own batch
                 else:
+                    print("-- No External launcher - work all batches")
                     prompts_to_use = all_prompts_text[::self.num_generations]  # Unique prompts for generation
 
                 # Generate completions

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -59,11 +59,6 @@ from .utils import (
     selective_log_softmax,
 )
 
-# import debugpy
-# debugpy.listen(("0.0.0.0", 5679))  # Allow remote debugging
-# print("\n\n\n\n-=-=-=-=-=-Waiting for debugger to attach...\n\n\n\n\n")
-# debugpy.wait_for_client()  # Execution will pause here until a debugger is attached
-
 if is_peft_available():
     from peft import PeftConfig, get_peft_model
 
@@ -458,9 +453,7 @@ class GRPOTrainer(Trainer):
                 if self.args.vllm_external_launcher:
                     # External launcher mode: Assign vLLM to the current process's device
                     vllm_device = f"{device_type}:{self.accelerator.process_index}"  
-                    print("---- Using external launcher - multi vllm")
                 else:
-                    print("---- Using single vllm")
                     vllm_device = self.args.vllm_device
                     if vllm_device == "auto":
                         # if self.args.vllm_external_launcher --> current device
@@ -738,10 +731,8 @@ class GRPOTrainer(Trainer):
 
             if self.args.vllm_external_launcher or self.accelerator.is_main_process:
                 if self.args.vllm_external_launcher:
-                    print("-- External launcher - work your own batch")
                     prompts_to_use = prompts_text  # Each GPU handles its own batch
                 else:
-                    print("-- No External launcher - work all batches")
                     prompts_to_use = all_prompts_text[::self.num_generations]  # Unique prompts for generation
 
                 # Generate completions

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -456,7 +456,6 @@ class GRPOTrainer(Trainer):
                 else:
                     vllm_device = self.args.vllm_device
                     if vllm_device == "auto":
-                        # if self.args.vllm_external_launcher --> current device
                         if device_module.device_count() == 1:
                             vllm_device = f"{device_type}:0"  # particular case when training with onyl 1 device: share it
                         else:
@@ -519,7 +518,7 @@ class GRPOTrainer(Trainer):
                     repetition_penalty=args.repetition_penalty,
                 )
 
-            self._last_loaded_step = 0  # Tag to avoid unnecessary loading during gradient accumulation
+            self._last_loaded_step = 0  # tag to avoid useless loading during grad accumulation
             if not self.args.vllm_external_launcher:
                 # When using vLLM, the main process is responsible for loading the model weights. This can cause process
                 # desynchronization and seems to lead to DeepSpeed hanging during initialization. To prevent this, we
@@ -726,7 +725,7 @@ class GRPOTrainer(Trainer):
                 self._move_model_to_vllm()
                 self._last_loaded_step = self.state.global_step
 
-            # Gather prompts only once if needed
+            # Generate completions using vLLM: gather all prompts and use them in a single call in the main process unless external launcher enabled
             all_prompts_text = gather_object(prompts_text) if not self.args.vllm_external_launcher else None
 
             if self.args.vllm_external_launcher or self.accelerator.is_main_process:

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -469,25 +469,25 @@ class GRPOTrainer(Trainer):
                         else:
                             vllm_device = f"{device_type}:{self.accelerator.num_processes}"  # take the next GPU idx
                 
-                # Check that the requested device is available
-                if (
-                    vllm_device.split(":")[0] == f"{device_type}"
-                    and int(vllm_device.split(":")[1]) >= device_module.device_count()
-                ):
-                    raise ValueError(
-                        f"The requested device for vllm ({vllm_device}) is not available. You are likely using vLLM "
-                        "without restricting the number of GPUs for training. Set the `--num_processes` argument to a "
-                        "value lower than the number of GPUs available on your machine—typically, reducing it by one "
-                        f"is sufficient. In your case: `--num_processes {device_module.device_count() - 1}`."
+                    # Check that the requested device is available
+                    if (
+                        vllm_device.split(":")[0] == f"{device_type}"
+                        and int(vllm_device.split(":")[1]) >= device_module.device_count()
+                    ):
+                        raise ValueError(
+                            f"The requested device for vllm ({vllm_device}) is not available. You are likely using vLLM "
+                            "without restricting the number of GPUs for training. Set the `--num_processes` argument to a "
+                            "value lower than the number of GPUs available on your machine—typically, reducing it by one "
+                            f"is sufficient. In your case: `--num_processes {device_module.device_count() - 1}`."
                     )
-                # Check that the requested device is not also used for training
-                if vllm_device in {f"{device_type}:{idx}" for idx in range(self.accelerator.num_processes)}:
-                    warnings.warn(
-                        f"The requested device {vllm_device} is also being used for training. For higher throughput "
-                        "and to avoid out-of-memory errors, it is recommended to use a dedicated device for vLLM. "
-                        "If this is intentional, you may ignore this warning but should adjust "
-                        "`vllm_gpu_memory_utilization` accordingly."
-                    )
+                    # Check that the requested device is not also used for training
+                    if vllm_device in {f"{device_type}:{idx}" for idx in range(self.accelerator.num_processes)}:
+                        warnings.warn(
+                            f"The requested device {vllm_device} is also being used for training. For higher throughput "
+                            "and to avoid out-of-memory errors, it is recommended to use a dedicated device for vLLM. "
+                            "If this is intentional, you may ignore this warning but should adjust "
+                            "`vllm_gpu_memory_utilization` accordingly."
+                        )
 
                 # Initialize LLM under ExitStack (only apply patches if not using external launcher)
                 with contextlib.ExitStack() as stack:

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -789,6 +789,8 @@ class GRPOTrainer(Trainer):
         prompt_inputs = super()._prepare_inputs(prompt_inputs)
         prompt_ids, prompt_mask = prompt_inputs["input_ids"], prompt_inputs["attention_mask"]
 
+        print("prompts:" , len(prompts), " prompts_text", len(prompts_text), " prompts_input ", len(prompt_inputs), "prompt_ids ", len(prompt_ids), "prompt mask ", len(prompt_mask))
+
         if self.max_prompt_length is not None:
             prompt_ids = prompt_ids[:, -self.max_prompt_length :]
             prompt_mask = prompt_mask[:, -self.max_prompt_length :]

--- a/trl/trainer/sft_config.py
+++ b/trl/trainer/sft_config.py
@@ -52,6 +52,11 @@ class SFTConfig(TrainingArguments):
             If `None`, no truncation is applied. When packing is enabled, this value sets the sequence length.
         packing (`bool`, *optional*, defaults to `False`):
             Whether to pack multiple sequences into a fixed-length format. Uses `max_length` to define sequence length.
+        padding_free (`bool`, *optional*, defaults to `False`):
+            Whether to perform forward passes without padding by flattening all sequences in the batch into a single
+            continuous sequence. This reduces memory usage by eliminating padding overhead. Currently, this is only
+            supported with the `flash_attention_2` attention implementation, which can efficiently handle the flattened
+            batch structure.
         eval_packing (`bool` or `None`, *optional*, defaults to `None`):
             Whether to pack the eval dataset. If `None`, uses the same value as `packing`.
 
@@ -100,6 +105,15 @@ class SFTConfig(TrainingArguments):
         metadata={
             "help": "Whether to pack multiple sequences into a fixed-length format. Uses `max_length` to define "
             "sequence length."
+        },
+    )
+    padding_free: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether to perform forward passes without padding by flattening all sequences in the batch into "
+            "a single continuous sequence. This reduces memory usage by eliminating padding overhead. Currently, "
+            "this is only supported with the `flash_attention_2` attention implementation, which can efficiently "
+            "handle the flattened batch structure."
         },
     )
     eval_packing: Optional[bool] = field(

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -422,7 +422,14 @@ class SFTTrainer(Trainer):
                     map_kwargs["desc"] = f"Tokenizing {dataset_name} dataset"
 
                 def tokenize(example, processing_class, dataset_text_field):
-                    return processing_class(text=example[dataset_text_field])
+                    processed = processing_class(text=example[dataset_text_field])
+                    if (
+                        processing_class.eos_token_id is not None
+                        and processed["input_ids"][-1] != processing_class.eos_token_id
+                    ):
+                        processed["input_ids"] = processed["input_ids"] + [processing_class.eos_token_id]
+                        processed["attention_mask"] = processed["attention_mask"] + [1]
+                    return processed
 
                 dataset = dataset.map(
                     tokenize,

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -422,7 +422,7 @@ class SFTTrainer(Trainer):
                     map_kwargs["desc"] = f"Tokenizing {dataset_name} dataset"
 
                 def tokenize(example, processing_class, dataset_text_field):
-                    return processing_class(example[dataset_text_field])
+                    return processing_class(text=example[dataset_text_field])
 
                 dataset = dataset.map(
                     tokenize,


### PR DESCRIPTION
# What does this PR do?


Fixes # (issue)

# Motivation
vLLM has introduced support for an external launcher, enabling vLLM processes to be co-located with other workloads, such as training.

Benefits of delivering External Launcher to the GRPO:
- Improved Inference Speed – It reduces the time required for GRPO training.
- Optimized GPU Utilization – Instead of dedicating an entire GPU solely to vLLM, multiple vLLM instances can now be colocated with training processes.

To leverage this feature, I added an option in TRL to spawn vLLM processes per GPU using the external launcher.

## Modifications in This PR:
This PR updates the GRPO trainer to:
- Introduce an option (self.args.vllm_external_launcher) to enable vLLM initialization via the external launcher.
- Initialize vLLM processes on each GPU using distributed_executor_backend="external_launcher".
- Remove the need to gather prompts across devices and set num_generation = 1, as each vLLM instance processes its own batch independently.
- This approach enables multi-vLLM execution in GRPO without relying on RAY, achieving efficiency gains with minimal modifications.

## Results:
- Running GRPO training with this configuration
<details>
  <summary>Click to view YAML</summary>

  ```yaml
  # Model arguments
  model_name_or_path: deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B
  model_revision: main
  torch_dtype: bfloat16
  attn_implementation: flash_attention_2
  
  # Data training arguments
  chat_template: "{% if not add_generation_prompt is defined %}{% set add_generation_prompt = false %}{% endif %}{% set ns = namespace(is_first=false, is_tool=false, is_output_first=true, system_prompt='') %}{%- for message in messages %}{%- if message['role'] == 'system' %}{% set ns.system_prompt = message['content'] %}{%- endif %}{%- endfor %}{{bos_token}}{{ns.system_prompt}}{%- for message in messages %}{%- if message['role'] == 'user' %}{%- set ns.is_tool = false -%}{{'<｜User｜>' + message['content']}}{%- endif %}{%- if message['role'] == 'assistant' and message['content'] is none %}{%- set ns.is_tool = false -%}{%- for tool in message['tool_calls']%}{%- if not ns.is_first %}{{'<｜Assistant｜><｜tool▁calls▁begin｜><｜tool▁call▁begin｜>' + tool['type'] + '<｜tool▁sep｜>' + tool['function']['name'] + '\\n' + '```json' + '\\n' + tool['function']['arguments'] + '\\n' + '```' + '<｜tool▁call▁end｜>'}}{%- set ns.is_first = true -%}{%- else %}{{'\\n' + '<｜tool▁call▁begin｜>' + tool['type'] + '<｜tool▁sep｜>' + tool['function']['name'] + '\\n' + '```json' + '\\n' + tool['function']['arguments'] + '\\n' + '```' + '<｜tool▁call▁end｜>'}}{{'<｜tool▁calls▁end｜><｜end▁of▁sentence｜>'}}{%- endif %}{%- endfor %}{%- endif %}{%- if message['role'] == 'assistant' and message['content'] is not none %}{%- if ns.is_tool %}{{'<｜tool▁outputs▁end｜>' + message['content'] + '<｜end▁of▁sentence｜>'}}{%- set ns.is_tool = false -%}{%- else %}{% set content = message['content'] %}{{'<｜Assistant｜>' + content + '<｜end▁of▁sentence｜>'}}{%- endif %}{%- endif %}{%- if message['role'] == 'tool' %}{%- set ns.is_tool = true -%}{%- if ns.is_output_first %}{{'<｜tool▁outputs▁begin｜><｜tool▁output▁begin｜>' + message['content'] + '<｜tool▁output▁end｜>'}}{%- set ns.is_output_first = false %}{%- else %}{{'\\n<｜tool▁output▁begin｜>' + message['content'] + '<｜tool▁output▁end｜>'}}{%- endif %}{%- endif %}{%- endfor -%}{% if ns.is_tool %}{{'<｜tool▁outputs▁end｜>'}}{% endif %}{% if add_generation_prompt and not ns.is_tool %}{{'<｜Assistant｜>'}}{% endif %}"
  dataset_name: open-r1/OpenR1-Math-220k # limo datasset is smaller - open-R1 fork of Fabian (problem key error will occur)
  system_prompt: "You are a helpful AI Assistant that provides well-reasoned and detailed responses. You first think about the reasoning process as an internal monologue and then provide the user with the answer. Respond in the following format: <think>\n...\n</think>\n<answer>\n...\n</answer>"
  
  # GRPO trainer config
  bf16: true
  use_vllm: true
  vllm_gpu_memory_utilization: 0.2
  vllm_enable_prefix_caching: false
  vllm_external_launcher: true # if this is set to false, set vllm_device: auto
  do_eval: false
  gradient_accumulation_steps: 4
  gradient_checkpointing: true
  gradient_checkpointing_kwargs:
    use_reentrant: false
  learning_rate: 1.0e-06
  log_completions: false
  log_level: info
  logging_first_step: true
  logging_steps: 1
  logging_strategy: steps
  lr_scheduler_type: cosine_with_min_lr
  lr_scheduler_kwargs:
    min_lr_rate: 0.1
  max_prompt_length: 512
  max_completion_length: 2048
  max_steps: 20
  num_generations: 16
  num_train_epochs: 1
  overwrite_output_dir: true
  per_device_train_batch_size: 16
  reward_funcs:
  - length
  save_total_limit: 1
  seed: 42
  temperature: 0.7
  warmup_ratio: 0.1
  ```
</details>

- resulted in 2× faster GRPO training (see attached figure)
![Screenshot 2025-03-17 at 7 32 35 PM](https://github.com/user-attachments/assets/76a2f956-01a4-4bfa-8817-7eb225b3dc9c)

To run an experiment w/ the config above, define ACCELERATE_CONFIG = recipes/accelerate_configs/zero2.yaml (from open-R1 repo) and define GRPO_CONFIG as provided above, then run
-  `ACCELERATE_LOG_LEVEL=info accelerate launch --config_file $ACCELERATE_CONFIG --num_processes=8 src/open_r1/grpo.py --config $GRPO_CONFIG`  for multi vllm scenario
- `ACCELERATE_LOG_LEVEL=info accelerate launch --config_file $ACCELERATE_CONFIG --num_processes=7 src/open_r1/grpo.py --config $GRPO_CONFIG`  for single vllm scenario (remember to set `vllm_external_launcher: false` and `vllm_device: auto`).


## Discussions:

### Why 2× speedup instead of 7–8×?
Previously, 7 GPUs were allocated for training and 1 GPU for generation. With this change, all GPUs are now utilized for both training and generation. Given that vLLMs are parallelized across all 8 GPUs, one might expect a 7–8× speedup. However, testing against a standalone vLLM instance also showed similar performance behavior as follows.

- Setup 1 (Single vLLM - original behavior of TRL): for per_device_train_batch = 16, num_gen = 16, device_count = 7..
Each of the 7 devices processes 16 prompts, leading to a global total of 112 prompts. The main vLLM process selects every 16th prompt, meaning a single vLLM gets 7 prompts and generates 112 generations. 

- Setup 2 (Multi-vLLM - w/ external launcher): Each vLLM processes a local batch of 16 and generates one output per input. This results in 16 generations per vLLM instance.

Setup1 showed 79 sec latency vs. setup2 showed 36sec latency for the deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B model.  The observed speedup was around 2×, aligning with our findings in GRPO training above.

Setup script is below.

<details>
  <summary>Click to view script</summary>

  ```python
  import random
  import lorem
  import os
  import argparse
  import time
  from vllm import LLM, SamplingParams
  
  def parse_arguments():
      parser = argparse.ArgumentParser(description="vLLM test to validate GPRO training savings.")
      parser.add_argument("--model_name", type=str, required=True, help="Name of the model to use")
      parser.add_argument("--no_of_prompts", type=int, default=112, help="Number of random prompts / batch size")
      parser.add_argument("--num_gen", type=int, default=1, help="Number of generations per prompt (n in SamplingParams)")
      return parser.parse_args()
  
  # Function to generate a random prompt with a given character length
  def generate_prompt():
      length = random.randint(100, 500)  
      prompt = lorem.paragraph()  
      while len(prompt) < length:
          prompt += " " + lorem.sentence()  
      return prompt[:length]  # Trim to exact length
  
  def initialize_llm(model_name):
      os.environ["CUDA_VISIBLE_DEVICES"] = "0"  # Ensure only GPU 0 is used
  
      llm = LLM(
          model=model_name,
          device="cuda",
          dtype="bfloat16",
          gpu_memory_utilization=0.3,
          enable_prefix_caching=False,
          max_model_len=None,  # Adjust as needed
      )
      return llm
  
  def run_inference(llm, prompts, num_gen):
      sampling_params = SamplingParams(
          max_tokens=2048,
          guided_decoding=None,
          n=num_gen,  # Number of generations per prompt
          temperature=0.7,
          top_p=1.0,
          top_k=50,
          min_p=0.0,
          repetition_penalty=1.0,
      )
  
      output = llm.generate(prompts, sampling_params)
 
      return output
  
  if __name__ == "__main__":
      args = parse_arguments()
  
      print(f"Initializing model: {args.model_name}")
      llm = initialize_llm(args.model_name)
  
      print(f"Generating {args.no_of_prompts} random prompts...")
      random_prompts = [generate_prompt() for _ in range(args.no_of_prompts)]
  
      print("Running inference...")
      start_time = time.time()
      results = run_inference(llm, random_prompts, args.num_gen)
      end_time = time.time()
  
      print(f"Inference completed in {end_time - start_time:.4f} seconds.")
  ```
</details>

We tried two different models (Qwen/Qwen2.5-Math-7B and deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B) and compared setup1 (no_of_prompts = 7, num_gen = 16) vs. setup2 (no_of_prompts = 16, num_gen = 1).  
`python script.py --model_name "Qwen/Qwen2.5-Math-7B" --no_of_prompts 16 --num_gen 2`


CC @fabianlim 

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.