### PR TITLE
Introduce TP in coloc mode

### DIFF
--- a/trl/extras/vllm_client.py
+++ b/trl/extras/vllm_client.py
@@ -14,7 +14,6 @@
 
 import atexit
 import logging
-import os
 import time
 from typing import Optional
 
@@ -343,47 +342,47 @@ class VLLMClient(VLLMNoOpClient):
 
 class VLLMColocationClient:
     """
-    A client class to interact with vLLM processes colocated with the training process.
+    A client class for interacting with vLLM models colocated with the training process.
 
-    This client bypasses remote communication and directly interacts with the in-process vLLM engine.
-    It supports weight updates and text generation functionalities similar to `VLLMClient`, but is optimized
-    for scenarios where vLLM is running in the same process or node as training.
+    This client eliminates remote communication overhead by directly interfacing with the in-process vLLM engine.
+    It supports weight updates and text generation, and is optimized for tensor-parallel setups where multiple
+    ranks share a single vLLM engine per node or process group.
 
     Args:
-        args (`GRPOConfig`): Configuration object containing vLLM parameters.
-        model (`transformers.PreTrainedModel`): The model being used.
-        vllm_device (`torch.device` or `str`): Device on which the model is loaded (e.g., "cuda:0").
+        args (GRPOConfig): Configuration object with vLLM-specific parameters.
+        model (transformers.PreTrainedModel): The model used for generation and weight updates.
+        accelerator_device (str): Device where the model is loaded.
+        accelerator_num_processes (int): Total number of distributed processes (world size).
+        accelerator_process_index (int): Index of the current process in the distributed setup.
     """
-
-    def __init__(self, args: GRPOConfig, model, accelerator):
+    def __init__(self, args: GRPOConfig, model, accelerator_device, accelerator_num_processes, accelerator_process_index):
         self.args = args
         self.model = model
-        self.accelerator = accelerator
-        self.vllm_device = accelerator.device
-        self.world_size = accelerator.num_processes
-        self.process_index = accelerator.process_index
+        self.vllm_device = accelerator_device
+        self.world_size = accelerator_num_processes
+        self.process_index = accelerator_process_index
         self._is_sleeping = False
         set_seed(42)
 
-        if self.args.vllm_colocation_tp:
-            # Ensure TP value is valid (at least 1)
-            assert self.args.vllm_colocation_tp >= 1, "vllm_colocation_tp must be greater than 0"
+        # Ensure TP value is valid (at least 1)
+        assert self.args.vllm_colocation >= 1, "vllm_colocation must be greater than 0"
 
-            # Make sure TP group size evenly divides the world size
-            # This ensures each group has the same number of ranks
-            assert self.world_size % self.args.vllm_colocation_tp == 0, (
-                f"TP size of vllm_colocation_tp ({self.args.vllm_colocation_tp}) must divide world size "
-                f"({self.world_size}) evenly."
-            )
-
-        # Create subgroups of ranks for TP, each group with `vllm_colocation_tp` ranks.
-        # For example, if world_size=8 and vllm_colocation_tp=2 → groups: [0,1], [2,3], [4,5], [6,7]
-        self.tp_group, _  = torch.distributed.new_subgroups_by_enumeration(
-            [
-                list(range(i*self.args.vllm_colocation_tp, (i+1) * self.args.vllm_colocation_tp)) 
-                for i in range(self.world_size // self.args.vllm_colocation_tp)
-            ]
+        # Make sure TP group size evenly divides the world size
+        # This ensures each group has the same number of ranks
+        assert self.world_size % self.args.vllm_colocation == 0, (
+            f"TP size of vllm_colocation ({self.args.vllm_colocation}) must divide world size "
+            f"({self.world_size}) evenly."
         )
+
+        if self.args.vllm_colocation > 1: # if model is sharded, create subgroups
+            # Create subgroups of ranks for TP, each group with `vllm_colocation` ranks.
+            # For example, if world_size=8 and vllm_colocation=2 → groups: [0,1], [2,3], [4,5], [6,7]
+            self.tp_group, _  = torch.distributed.new_subgroups_by_enumeration(
+                [
+                    list(range(i*self.args.vllm_colocation, (i+1) * self.args.vllm_colocation)) 
+                    for i in range(self.world_size // self.args.vllm_colocation)
+                ]
+            )
 
         self.llm = LLM(
             model=self.model.name_or_path,
@@ -392,19 +391,31 @@ class VLLMColocationClient:
             dtype=self.args.vllm_dtype,
             enable_prefix_caching=self.args.vllm_enable_prefix_caching,
             max_model_len=self.args.vllm_max_model_len,
-            tensor_parallel_size=args.vllm_colocation_tp, 
+            tensor_parallel_size=args.vllm_colocation, 
             distributed_executor_backend="external_launcher",
             enable_sleep_mode=True,
-            max_num_seqs=self.args.per_device_train_batch_size * self.args.vllm_colocation_tp
+            max_num_seqs=self.args.per_device_train_batch_size * self.args.vllm_colocation
         )
     
-    def wake_up_vllm(self):
+    def maybe_wake_up_vllm(self):
+        """
+        Wakes up the vLLM engine if it is currently in sleep mode.
+
+        This is useful before any generation or weight update calls to ensure the model is active.
+        It also calls `torch.cuda.empty_cache()` to free unused memory, helping avoid OOM errors.
+        """
         torch.cuda.empty_cache()
         if self.args.vllm_sleep_enabled and self._is_sleeping:
             self.llm.wake_up()
             self._is_sleeping = False
 
-    def sleep_vllm(self):
+    def maybe_sleep_vllm(self):
+        """
+        Puts the vLLM engine into sleep mode after generation is complete.
+
+        This helps conserve memory by offloading cached resources. 
+        The sleep only happens if `vllm_sleep_enabled` is set to True in the config.
+        """
         if self.args.vllm_sleep_enabled:
             self.llm.sleep(level=1)
             self._is_sleeping = True
@@ -419,7 +430,7 @@ class VLLMColocationClient:
             weights (`torch.Tensor`):
                 Tensor containing the updated weights.
         """
-        self.wake_up_vllm()
+        self.maybe_wake_up_vllm()
         llm_model = self.llm.llm_engine.model_executor.driver_worker.model_runner.model
         llm_model.load_weights([(name,weights)])
 
@@ -462,7 +473,7 @@ class VLLMColocationClient:
             `list[list[int]]`:
                 List of lists of token IDs representing the model-generated completions for each prompt.
         """
-        self.wake_up_vllm()
+        self.maybe_wake_up_vllm()
 
         # Guided decoding, if enabled
         if guided_decoding_regex is not None:
@@ -470,11 +481,11 @@ class VLLMColocationClient:
         else:
             guided_decoding = None
 
-        if self.args.vllm_colocation_tp:
+        if self.args.vllm_colocation > 1:
             # Gather prompts from all ranks in the TP group and flatten.
             # Each rank starts with its own prompts; after gathering, all ranks see the full group set.
             orig_size = len(prompts)
-            gathered_prompts = [None for _ in range(self.args.vllm_colocation_tp)]
+            gathered_prompts = [None for _ in range(self.args.vllm_colocation)]
             torch.distributed.all_gather_object(gathered_prompts, prompts, group=self.tp_group)
             prompts = [p for sublist in gathered_prompts for p in sublist]
 
@@ -495,14 +506,14 @@ class VLLMColocationClient:
 
         completion_ids = [output.token_ids for outputs in all_outputs for output in outputs.outputs]
 
-        if self.args.vllm_colocation_tp:
+        if self.args.vllm_colocation > 1:
             # Slice completions for this rank within its TP group.
             # Each rank generates all outputs — we keep only our share.
             local_rank_in_group = torch.distributed.get_rank(group=self.tp_group)
             tp_slice = slice(local_rank_in_group * orig_size, (local_rank_in_group + 1) * orig_size)
             completion_ids = completion_ids[tp_slice]
 
-        self.sleep_vllm()
+        self.maybe_sleep_vllm()
         return completion_ids
 
     def reset_prefix_cache(self):
@@ -528,8 +539,8 @@ def get_vllm_client(args: GRPOConfig, model, accelerator: Accelerator) -> VLLMNo
         model (`transformers.PreTrainedModel`): The model to use, passed only for the colocated client.
         accelerator (`Accelerator`): Hugging Face `Accelerator` object that helps with multi-GPU training.
     """
-    if args.vllm_colocation_tp:
-        return VLLMColocationClient(args, model, accelerator)
+    if args.vllm_colocation:
+        return VLLMColocationClient(args, model, accelerator.device, accelerator.num_processes, accelerator.process_index)
     elif accelerator.is_main_process:
         return VLLMClient(
             args.vllm_server_host, args.vllm_server_port, connection_timeout=args.vllm_server_timeout,

--- a/trl/extras/vllm_client.py
+++ b/trl/extras/vllm_client.py
@@ -472,7 +472,8 @@ class VLLMColocationClient:
         """
         torch.cuda.empty_cache()
         # Load model during grad accumulation steps (we lost model weights during previous sleep for memory)
-        self.load_model_during_grad_accumulation()
+        # self.load_model_during_grad_accumulation()
+        self.llm.wake_up()
 
         # Guided decoding, if enabled
         if guided_decoding_regex is not None:
@@ -516,7 +517,7 @@ class VLLMColocationClient:
             tp_slice = slice(local_rank_in_group * orig_size, (local_rank_in_group + 1) * orig_size)
             completion_ids = completion_ids[tp_slice]
 
-        self.llm.sleep(level=2)
+        self.llm.sleep(level=1)
         self._model_needs_loading = True # we lose the weights after sleep - so ensure to reload it before next generation
         return completion_ids
 

--- a/trl/extras/vllm_client.py
+++ b/trl/extras/vllm_client.py
@@ -362,7 +362,7 @@ class VLLMColocationClient:
         self.world_size = accelerator.num_processes
         self.process_index = accelerator.process_index
         set_seed(42)
-        # print(f"\n------ device {self.vllm_device}, tp size: {self.args.vllm_colocation_tp}, process index: {self.process_index}, process length {self.world_size}")
+        print(f"\n\n------ device {self.vllm_device}, tp size: {self.args.vllm_colocation_tp}, process index: {self.process_index}, process length {self.world_size}")
 
         if self.args.vllm_colocation_tp:
             # Ensure TP value is valid (at least 1)
@@ -469,7 +469,9 @@ class VLLMColocationClient:
             torch.distributed.all_gather_object(gathered_prompts, prompts, group=self.tp_group)
             prompts = [p for sublist in gathered_prompts for p in sublist]
 
-        # print("\n\n---Rank ", self.process_index, " colocation check prompts, orig_size: ", orig_size, " local group prompts size", len(prompts), " should be equal to ", orig_size*self.args.vllm_colocation_tp )
+        print(f"\n\n---Rank {self.process_index} colocation check prompts, "
+          f"orig_size: {orig_size}, local group prompts size: {len(prompts)}, "
+          f"should be equal to: {orig_size * self.args.vllm_colocation_tp}")
 
         sampling_params = SamplingParams(
             n=1, # vLLM on each device generates only 1 in vllm_colocation mode
@@ -503,9 +505,8 @@ class VLLMColocationClient:
         Resets the prefix cache for the model.
         """
         # ToDo: perhaps we need to just pass 
-        self.llm.wake_up()
+        # no need to wake up already awake)
         self.llm.reset_prefix_cache()
-        self.llm.sleep(level=2)
 
 def get_vllm_client(args: GRPOConfig, model, accelerator: Accelerator) -> VLLMNoOpClient:
     """

--- a/trl/extras/vllm_client.py
+++ b/trl/extras/vllm_client.py
@@ -368,12 +368,13 @@ class VLLMColocationClient:
         num_processes (int): Total number of distributed processes (world size).
         process_index (int): Index of the current process in the distributed setup.
     """
-    def __init__(self, args: GRPOConfig, model, device, num_processes, process_index):
+    def __init__(self, args: GRPOConfig, model, device, num_processes, process_index, accelerator):
         self.args = args
         self.model = model
         self.vllm_device = device
         self.world_size = num_processes
         self.process_index = process_index
+        self.accelerator = accelerator
         self._is_sleeping = False
         self._grad_accumulation = True
         set_seed(42)
@@ -581,7 +582,7 @@ def get_vllm_client(args: GRPOConfig, model, accelerator: Accelerator) -> VLLMNo
         accelerator (`Accelerator`): Hugging Face `Accelerator` object that helps with multi-GPU training.
     """
     if args.vllm_colocation:
-        return VLLMColocationClient(args, model, accelerator.device, accelerator.num_processes, accelerator.process_index)
+        return VLLMColocationClient(args, model, accelerator.device, accelerator.num_processes, accelerator.process_index, accelerator)
     elif accelerator.is_main_process:
         return VLLMClient(
             args.vllm_server_host, args.vllm_server_port, connection_timeout=args.vllm_server_timeout,

--- a/trl/extras/vllm_client.py
+++ b/trl/extras/vllm_client.py
@@ -386,10 +386,10 @@ class VLLMColocationClient:
                 Tensor containing the updated weights.
         """
         print(self.process_index, "------------- Updating model - waking up")
-        mem = torch.cuda.memory_allocated()
+        mem = torch.cuda.memory_reserved()
         print(self.process_index, "------------- Mememory before empty_cache in updating model", mem)
         torch.cuda.empty_cache()
-        mem = torch.cuda.memory_allocated()
+        mem = torch.cuda.memory_reserved()
         print(self.process_index, "------------- memory after empty_cache, and waking up in updating model", mem)
         self.llm.wake_up()
         llm_model = self.llm.llm_engine.model_executor.driver_worker.model_runner.model
@@ -439,11 +439,10 @@ class VLLMColocationClient:
                 List of lists of token IDs representing the model-generated completions for each prompt.
         """
         print(self.process_index, "------------- Generation")
-        mem = torch.cuda.memory_allocated()
+        mem = torch.cuda.memory_reserved()
         print("------------- Mememory before empty_cache", mem)
         torch.cuda.empty_cache()
-
-        mem = torch.cuda.memory_allocated()
+        mem = torch.cuda.memory_reserved()
         print(self.process_index, "------------- memory after empty_cache, and waking up", mem)
 
         self.llm.wake_up()

--- a/trl/extras/vllm_client.py
+++ b/trl/extras/vllm_client.py
@@ -496,6 +496,15 @@ class VLLMColocationClient:
             prompts, sampling_params=sampling_params, use_tqdm=False
         )
 
+        if self.process_index == 0:
+            print("\n\n==== Rank 0 Prompt/Generation Output ====\n")
+            for i, (prompt, outputs) in enumerate(zip(prompts, all_outputs)):
+                print(f"--- Prompt {i+1} ---")
+                print(prompt)
+                print(f"--- Generation {i+1} ---")
+                print(outputs.outputs[0].text.strip())
+                print("=" * 40)
+
         completion_ids = [output.token_ids for outputs in all_outputs for output in outputs.outputs]
 
         if self.args.vllm_colocation_tp:
@@ -514,14 +523,13 @@ class VLLMColocationClient:
         self._accumulation_step += 1
 
         if self.process_index == 0:
-            print(f"[RANK 0] generate done. Updated accumulation_step to {self._accumulation_step} and is_grad_accum was {is_grad_accum}")
+            print(f"[RANK 0] generate done. Updated accumulation_step to {self._accumulation_step} and sleep level was 1 during grad accumulation {is_grad_accum}")
         return completion_ids
 
     def reset_prefix_cache(self):
         """
         Resets the prefix cache for the model.
         """
-        # ToDo: perhaps we need to just pass 
         self.llm.reset_prefix_cache()
         if self.process_index == 0:
             print(f"[RANK 0] reset_prefix_cache done.")

--- a/trl/extras/vllm_client.py
+++ b/trl/extras/vllm_client.py
@@ -383,7 +383,7 @@ class VLLMColocationClient:
             weights (`torch.Tensor`):
                 Tensor containing the updated weights.
         """
-        self.wake_up()
+        self.llm.wake_up()
         llm_model = self.llm.llm_engine.model_executor.driver_worker.model_runner.model
         llm_model.load_weights([(name,weights)])
 
@@ -442,8 +442,6 @@ class VLLMColocationClient:
             orig_size = len(prompts) # size of local prompts (for splitting later)
             prompts = self._gather(prompts) 
 
-            print("-----\n orig size", orig_size , " prompt size", len(prompts))
-
         sampling_params = SamplingParams(
             n=num_gen, # vLLM on each GPU generates only 1 in vllm_colocation mode, args.num_generations (or 1?) in vllm_tp mode
             repetition_penalty=repetition_penalty,
@@ -460,7 +458,6 @@ class VLLMColocationClient:
         )
 
         completion_ids = [output.token_ids for outputs in all_outputs for output in outputs.outputs]
-        print("-----\n completion id size", len(completion_ids))
 
         if self.args.vllm_tp:
             # just do split - no broadcast!
@@ -469,7 +466,6 @@ class VLLMColocationClient:
                 (self.process_index  + 1) * orig_size
             )
             completion_ids = completion_ids[tp_slice]
-            print("-----\n Sliced completion id size", len(completion_ids), " and slice: ", tp_slice)
 
         self.llm.sleep(level=2)
 

--- a/trl/extras/vllm_client.py
+++ b/trl/extras/vllm_client.py
@@ -393,6 +393,7 @@ class VLLMColocationClient:
             max_model_len=self.args.vllm_max_model_len,
             tensor_parallel_size=args.vllm_colocation_tp, 
             distributed_executor_backend="external_launcher",
+            enable_sleep_mode=True,
             max_num_seqs=self.args.per_device_train_batch_size * self.args.vllm_colocation_tp
         )
         

--- a/trl/extras/vllm_client.py
+++ b/trl/extras/vllm_client.py
@@ -436,7 +436,7 @@ class VLLMColocationClient:
         if self.args.vllm_sleep_enabled and self._is_sleeping:
             self.llm.wake_up()
             print(f"\n\n---Rank {self.process_index} woke up now") if self.process_index == 0 else None
-            if self._grad_accumulation:
+            if self._grad_accumulation and self.args.vllm_sleep_level2:
                 self.load_model_during_grad_accumulation()
             self._is_sleeping = False
 
@@ -449,7 +449,7 @@ class VLLMColocationClient:
         """
         if self.args.vllm_sleep_enabled:
             print(f"\n\n---Rank {self.process_index} sleeping now with level 2") if self.process_index == 0 else None
-            self.llm.sleep(level=2)
+            self.llm.sleep(level=2) if self.args.vllm_sleep_level2 else self.llm.sleep(level=1)
             self._is_sleeping = True
         
     def update_named_param(self, name: str, weights: torch.Tensor):

--- a/trl/extras/vllm_client.py
+++ b/trl/extras/vllm_client.py
@@ -14,6 +14,7 @@
 
 import atexit
 import logging
+import os
 import time
 from typing import Optional
 
@@ -406,10 +407,11 @@ class VLLMColocationClient:
             dtype=self.args.vllm_dtype,
             enable_prefix_caching=self.args.vllm_enable_prefix_caching,
             max_model_len=self.args.vllm_max_model_len,
-            tensor_parallel_size=args.vllm_colocation, 
+            tensor_parallel_size=self.args.vllm_colocation, 
             distributed_executor_backend="external_launcher",
             enable_sleep_mode=self.args.vllm_sleep_enabled,
-            max_num_seqs=self.args.per_device_train_batch_size * self.args.vllm_colocation
+            max_num_seqs=self.args.per_device_train_batch_size * self.args.vllm_colocation,
+            seed=int(os.getenv("RANK", "0")) // self.args.vllm_colocation, 
         )
     
     def load_model_during_grad_accumulation(self):

--- a/trl/extras/vllm_client.py
+++ b/trl/extras/vllm_client.py
@@ -20,7 +20,7 @@ from typing import Optional
 import torch
 from torch import nn
 
-from ..import_utils import is_requests_available, is_vllm_ascend_available, is_vllm_available
+from ..import_utils import is_requests_available, is_vllm_ascend_available, is_vllm_available, is_deepspeed_available
 
 from ..trainer.grpo_config import GRPOConfig
 

--- a/trl/extras/vllm_client.py
+++ b/trl/extras/vllm_client.py
@@ -400,13 +400,14 @@ class VLLMColocationClient:
     
     def wake_up_vllm(self):
         torch.cuda.empty_cache()
-        if self._is_sleeping:
+        if self.args.vllm_sleep_enabled and self._is_sleeping:
             self.llm.wake_up()
             self._is_sleeping = False
 
     def sleep_vllm(self):
-        self.llm.sleep(level=1)
-        self._is_sleeping = True
+        if self.args.vllm_sleep_enabled:
+            self.llm.sleep(level=1)
+            self._is_sleeping = True
         
     def update_named_param(self, name: str, weights: torch.Tensor):
         """

--- a/trl/extras/vllm_client.py
+++ b/trl/extras/vllm_client.py
@@ -362,7 +362,7 @@ class VLLMColocationClient:
         self.world_size = accelerator.num_processes
         self.process_index = accelerator.process_index
         set_seed(42)
-        print(f"\n------ device {self.vllm_device}, tp size: {self.args.vllm_colocation_tp}, process index: {self.process_index}, process length {self.world_size}")
+        # print(f"\n------ device {self.vllm_device}, tp size: {self.args.vllm_colocation_tp}, process index: {self.process_index}, process length {self.world_size}")
 
         if self.args.vllm_colocation_tp:
             # Ensure TP value is valid (at least 1)
@@ -469,7 +469,7 @@ class VLLMColocationClient:
             torch.distributed.all_gather_object(gathered_prompts, prompts, group=self.tp_group)
             prompts = [p for sublist in gathered_prompts for p in sublist]
 
-        print("\n\n---Rank ", self.process_index, " colocation check prompts, orig_size: ", orig_size, " local group prompts size", len(prompts), " should be equal to ", orig_size*self.args.vllm_colocation_tp )
+        # print("\n\n---Rank ", self.process_index, " colocation check prompts, orig_size: ", orig_size, " local group prompts size", len(prompts), " should be equal to ", orig_size*self.args.vllm_colocation_tp )
 
         sampling_params = SamplingParams(
             n=1, # vLLM on each device generates only 1 in vllm_colocation mode

--- a/trl/extras/vllm_client.py
+++ b/trl/extras/vllm_client.py
@@ -448,8 +448,12 @@ class VLLMColocationClient:
         The sleep only happens if `vllm_sleep_enabled` is set to True in the config.
         """
         if self.args.vllm_sleep_enabled:
-            print(f"\n\n---Rank {self.process_index} sleeping now with level 2") if self.process_index == 0 else None
-            self.llm.sleep(level=2) if self.args.vllm_sleep_level2 else self.llm.sleep(level=1)
+            if self.args.vllm_sleep_level2:
+                print(f"\n\n---Rank {self.process_index} sleeping now with level 2") if self.process_index == 0 else None
+                self.llm.sleep(level=2)  
+            else: 
+                print(f"\n\n---Rank {self.process_index} sleeping now with level 1") if self.process_index == 0 else None
+                self.llm.sleep(level=1)
             self._is_sleeping = True
         
     def update_named_param(self, name: str, weights: torch.Tensor):

--- a/trl/extras/vllm_client.py
+++ b/trl/extras/vllm_client.py
@@ -359,6 +359,7 @@ class VLLMColocationClient:
         self.model = model
         self.vllm_device = accelerator.device
         self.tp_size = accelerator.num_processes
+        self.process_index = accelerator.process_index
 
         self.llm = LLM(
             model=self.model.name_or_path,

--- a/trl/extras/vllm_client.py
+++ b/trl/extras/vllm_client.py
@@ -400,6 +400,7 @@ class VLLMColocationClient:
             dtype=self.args.vllm_dtype,
             enable_prefix_caching=self.args.vllm_enable_prefix_caching,
             max_model_len=self.args.vllm_max_model_len,
+            max_num_batched_tokens=self.args.vllm_max_model_len,
             tensor_parallel_size=args.vllm_colocation, 
             distributed_executor_backend="external_launcher",
             enable_sleep_mode=self.args.vllm_sleep_enabled,

--- a/trl/extras/vllm_client.py
+++ b/trl/extras/vllm_client.py
@@ -359,16 +359,16 @@ class VLLMColocationClient:
     Args:
         args (GRPOConfig): Configuration object with vLLM-specific parameters.
         model (transformers.PreTrainedModel): The model used for generation and weight updates.
-        accelerator_device (str): Device where the model is loaded.
-        accelerator_num_processes (int): Total number of distributed processes (world size).
-        accelerator_process_index (int): Index of the current process in the distributed setup.
+        device (str): Device where the model is loaded.
+        num_processes (int): Total number of distributed processes (world size).
+        process_index (int): Index of the current process in the distributed setup.
     """
-    def __init__(self, args: GRPOConfig, model, accelerator_device, accelerator_num_processes, accelerator_process_index):
+    def __init__(self, args: GRPOConfig, model, device, num_processes, process_index):
         self.args = args
         self.model = model
-        self.vllm_device = accelerator_device
-        self.world_size = accelerator_num_processes
-        self.process_index = accelerator_process_index
+        self.vllm_device = device
+        self.world_size = num_processes
+        self.process_index = process_index
         self._is_sleeping = False
         set_seed(42)
 
@@ -401,7 +401,7 @@ class VLLMColocationClient:
             max_model_len=self.args.vllm_max_model_len,
             tensor_parallel_size=args.vllm_colocation, 
             distributed_executor_backend="external_launcher",
-            enable_sleep_mode=True,
+            enable_sleep_mode=self.args.vllm_sleep_enabled,
             max_num_seqs=self.args.per_device_train_batch_size * self.args.vllm_colocation
         )
     

--- a/trl/extras/vllm_client.py
+++ b/trl/extras/vllm_client.py
@@ -14,6 +14,7 @@
 
 import atexit
 import logging
+import os
 import time
 from typing import Optional
 
@@ -355,11 +356,36 @@ class VLLMColocationClient:
     """
 
     def __init__(self, args: GRPOConfig, model, accelerator):
-        self.args: GRPOConfig = args
+        self.args = args
         self.model = model
         self.vllm_device = accelerator.device
-        self.tp_size = accelerator.num_processes
+        self.world_size = accelerator.num_processes
         self.process_index = accelerator.process_index
+        set_seed(42)
+        print(f"\n------ device {self.vllm_device}, tp size: {self.args.vllm_colocation_tp}, process index: {self.process_index}, process length {self.world_size}")
+
+        if self.args.vllm_colocation_tp:
+            # Ensure TP value is valid (at least 1)
+            assert self.args.vllm_colocation_tp >= 1, "vllm_colocation_tp must be greater than 0"
+
+            # Get local world size from environment (https://pytorch.org/docs/stable/elastic/run.html#environment-variables)
+            self.local_world_size = int(os.environ["LOCAL_WORLD_SIZE"])
+
+            # Make sure TP group size evenly divides the local world size
+            # This ensures each group has the same number of ranks
+            assert self.local_world_size % self.args.vllm_colocation_tp == 0, (
+                f"TP size of vllm_colocation_tp ({self.args.vllm_colocation_tp}) must divide LOCAL_WORLD_SIZE "
+                f"({self.local_world_size}) evenly."
+            )
+
+        # Create subgroups of ranks for TP, each group with `vllm_colocation_tp` ranks.
+        # For example, if world_size=8 and vllm_colocation_tp=2 → groups: [0,1], [2,3], [4,5], [6,7]
+        self.tp_group, _  = torch.distributed.new_subgroups_by_enumeration(
+            [
+                list(range(i*self.args.vllm_colocation_tp, (i+1) * self.args.vllm_colocation_tp)) 
+                for i in range(self.world_size // self.args.vllm_colocation_tp)
+            ]
+        )
 
         self.llm = LLM(
             model=self.model.name_or_path,
@@ -368,7 +394,7 @@ class VLLMColocationClient:
             dtype=self.args.vllm_dtype,
             enable_prefix_caching=self.args.vllm_enable_prefix_caching,
             max_model_len=self.args.vllm_max_model_len,
-            tensor_parallel_size=self.tp_size if args.vllm_tp else 1,
+            tensor_parallel_size=args.vllm_colocation_tp, 
             distributed_executor_backend="external_launcher",
             enable_sleep_mode=True
         )
@@ -387,9 +413,6 @@ class VLLMColocationClient:
         self.llm.wake_up()
         llm_model = self.llm.llm_engine.model_executor.driver_worker.model_runner.model
         llm_model.load_weights([(name,weights)])
-
-    def _gather(self, prompts):
-        return gather_object(prompts) 
 
     def generate(
         self,
@@ -438,12 +461,18 @@ class VLLMColocationClient:
         else:
             guided_decoding = None
 
-        if self.args.vllm_tp:
-            orig_size = len(prompts) # size of local prompts (for splitting later)
-            prompts = self._gather(prompts) 
+        if self.args.vllm_colocation_tp:
+            # Gather prompts from all ranks in the TP group and flatten.
+            # Each rank starts with its own prompts; after gathering, all ranks see the full group set.
+            orig_size = len(prompts)
+            gathered_prompts = [None for _ in range(self.args.vllm_colocation_tp)]
+            torch.distributed.all_gather_object(gathered_prompts, prompts, group=self.tp_group)
+            prompts = [p for sublist in gathered_prompts for p in sublist]
+
+        print("\n\n---Rank ", self.process_index, " colocation check prompts, orig_size: ", orig_size, " local group prompts size", len(prompts), " should be equal to ", orig_size*self.args.vllm_colocation_tp )
 
         sampling_params = SamplingParams(
-            n=1, # vLLM on each GPU generates only 1 in vllm_colocation mode
+            n=1, # vLLM on each device generates only 1 in vllm_colocation mode
             repetition_penalty=repetition_penalty,
             temperature=temperature,
             top_p=top_p,
@@ -459,12 +488,11 @@ class VLLMColocationClient:
 
         completion_ids = [output.token_ids for outputs in all_outputs for output in outputs.outputs]
 
-        if self.args.vllm_tp:
-            # just do split - no broadcast!
-            tp_slice = slice(
-                self.process_index * orig_size,
-                (self.process_index  + 1) * orig_size
-            )
+        if self.args.vllm_colocation_tp:
+            # Slice completions for this rank within its TP group.
+            # Each rank generates all outputs — we keep only our share.
+            local_rank_in_group = torch.distributed.get_rank(group=self.tp_group)
+            tp_slice = slice(local_rank_in_group * orig_size, (local_rank_in_group + 1) * orig_size)
             completion_ids = completion_ids[tp_slice]
 
         self.llm.sleep(level=2)
@@ -496,7 +524,7 @@ def get_vllm_client(args: GRPOConfig, model, accelerator: Accelerator) -> VLLMNo
         model (`transformers.PreTrainedModel`): The model to use, passed only for the colocated client.
         accelerator (`Accelerator`): Hugging Face `Accelerator` object that helps with multi-GPU training.
     """
-    if args.vllm_colocation or args.vllm_tp:
+    if args.vllm_colocation_tp:
         return VLLMColocationClient(args, model, accelerator)
     elif accelerator.is_main_process:
         return VLLMClient(

--- a/trl/extras/vllm_client.py
+++ b/trl/extras/vllm_client.py
@@ -393,7 +393,7 @@ class VLLMColocationClient:
             max_model_len=self.args.vllm_max_model_len,
             tensor_parallel_size=args.vllm_colocation_tp, 
             distributed_executor_backend="external_launcher",
-            enable_sleep_mode=True
+            max_num_seqs=self.args.per_device_train_batch_size * self.args.vllm_colocation_tp
         )
         
     def update_named_param(self, name: str, weights: torch.Tensor):

--- a/trl/extras/vllm_client.py
+++ b/trl/extras/vllm_client.py
@@ -425,7 +425,7 @@ class VLLMColocationClient:
         The sleep only happens if `vllm_sleep_enabled` is set to True in the config.
         """
         if self.args.vllm_sleep_enabled:
-            self.llm.sleep(level=1)
+            self.llm.sleep(level=2)
             self._is_sleeping = True
         
     def update_named_param(self, name: str, weights: torch.Tensor):

--- a/trl/extras/vllm_client.py
+++ b/trl/extras/vllm_client.py
@@ -473,12 +473,12 @@ class VLLMColocationClient:
             prompts, sampling_params=sampling_params, use_tqdm=False
         )
 
-        self.llm.sleep(level=2)
-
         completion_ids = [output.token_ids for outputs in all_outputs for output in outputs.outputs]
 
         if self.args.vllm_tp:
             completion_ids = self._broadcast_and_slice(completion_ids, orig_size)
+
+        self.llm.sleep(level=2)
 
         return completion_ids
 
@@ -486,9 +486,10 @@ class VLLMColocationClient:
         """
         Resets the prefix cache for the model.
         """
-        self.llm.wake_up()
-        self.llm.reset_prefix_cache()
-        self.llm.sleep(level=2)
+        pass 
+        # self.llm.wake_up()
+        # self.llm.reset_prefix_cache()
+        # self.llm.sleep(level=2)
 
 def get_vllm_client(args: GRPOConfig, model, accelerator: Accelerator) -> VLLMNoOpClient:
     """

--- a/trl/extras/vllm_client.py
+++ b/trl/extras/vllm_client.py
@@ -368,14 +368,11 @@ class VLLMColocationClient:
             # Ensure TP value is valid (at least 1)
             assert self.args.vllm_colocation_tp >= 1, "vllm_colocation_tp must be greater than 0"
 
-            # Get local world size from environment (https://pytorch.org/docs/stable/elastic/run.html#environment-variables)
-            self.local_world_size = int(os.environ["LOCAL_WORLD_SIZE"])
-
-            # Make sure TP group size evenly divides the local world size
+            # Make sure TP group size evenly divides the world size
             # This ensures each group has the same number of ranks
-            assert self.local_world_size % self.args.vllm_colocation_tp == 0, (
-                f"TP size of vllm_colocation_tp ({self.args.vllm_colocation_tp}) must divide LOCAL_WORLD_SIZE "
-                f"({self.local_world_size}) evenly."
+            assert self.world_size % self.args.vllm_colocation_tp == 0, (
+                f"TP size of vllm_colocation_tp ({self.args.vllm_colocation_tp}) must divide world size "
+                f"({self.world_size}) evenly."
             )
 
         # Create subgroups of ranks for TP, each group with `vllm_colocation_tp` ranks.

--- a/trl/extras/vllm_client.py
+++ b/trl/extras/vllm_client.py
@@ -361,7 +361,7 @@ class VLLMColocationClient:
         self.tp_size = accelerator.num_processes
         self.process_index = accelerator.process_index
 
-        print("\n\n\n\n\n------------- Initializing LLM")
+        # print("\n\n\n\n\n------------- Initializing LLM")
         self.llm = LLM(
             model=self.model.name_or_path,
             device=self.vllm_device,
@@ -373,7 +373,7 @@ class VLLMColocationClient:
             distributed_executor_backend="external_launcher",
             enable_sleep_mode=True
         )
-        print("------------- Initialized LLM")
+        # print("------------- Initialized LLM")
         
     def update_named_param(self, name: str, weights: torch.Tensor):
         """
@@ -385,16 +385,16 @@ class VLLMColocationClient:
             weights (`torch.Tensor`):
                 Tensor containing the updated weights.
         """
-        print(self.process_index, "------------- Updating model - waking up")
+        # print(self.process_index, "------------- Updating model - waking up")
         mem = torch.cuda.memory_reserved()
-        print(self.process_index, "------------- Mememory before empty_cache in updating model", mem)
+        # print(self.process_index, "------------- Mememory before empty_cache in updating model", mem)
         torch.cuda.empty_cache()
         mem = torch.cuda.memory_reserved()
-        print(self.process_index, "------------- memory after empty_cache, and waking up in updating model", mem)
+        # print(self.process_index, "------------- memory after empty_cache, and waking up in updating model", mem)
         self.llm.wake_up()
         llm_model = self.llm.llm_engine.model_executor.driver_worker.model_runner.model
         llm_model.load_weights([(name,weights)])
-        print(self.process_index, "------------- Updated the model")
+        # print(self.process_index, "------------- Updated the model")
 
     def _gather(self, prompts):
         return gather_object(prompts) 
@@ -438,15 +438,15 @@ class VLLMColocationClient:
             `list[list[int]]`:
                 List of lists of token IDs representing the model-generated completions for each prompt.
         """
-        print(self.process_index, "------------- Generation")
-        mem = torch.cuda.memory_reserved()
-        print("------------- Mememory before empty_cache", mem)
+        # print(self.process_index, "------------- Generation")
+        # mem = torch.cuda.memory_reserved()
+        # print("------------- Mememory before empty_cache", mem)
         torch.cuda.empty_cache()
-        mem = torch.cuda.memory_reserved()
-        print(self.process_index, "------------- memory after empty_cache, and waking up", mem)
+        # mem = torch.cuda.memory_reserved()
+        # print(self.process_index, "------------- memory after empty_cache, and waking up", mem)
 
         self.llm.wake_up()
-        print(self.process_index, "------------- Woke up, will do generation")
+        # print(self.process_index, "------------- Woke up, will do generation")
         # Guided decoding, if enabled
         if guided_decoding_regex is not None:
             guided_decoding = GuidedDecodingParams(backend="outlines", regex=guided_decoding_regex)
@@ -484,7 +484,7 @@ class VLLMColocationClient:
             completion_ids = completion_ids[tp_slice]
 
         self.llm.sleep(level=2)
-        print(self.process_index, "------------- GEnerated, going back to sleep")
+        # print(self.process_index, "------------- GEnerated, going back to sleep")
 
         return completion_ids
 
@@ -493,11 +493,11 @@ class VLLMColocationClient:
         Resets the prefix cache for the model.
         """
         # pass 
-        print(self.process_index, "------------- Will reset prefix cache now - waking up")
+        # print(self.process_index, "------------- Will reset prefix cache now - waking up")
         self.llm.wake_up()
         self.llm.reset_prefix_cache()
         self.llm.sleep(level=2)
-        print(self.process_index, "------------- Reset done, going back to sleep")
+        # print(self.process_index, "------------- Reset done, going back to sleep")
 
 def get_vllm_client(args: GRPOConfig, model, accelerator: Accelerator) -> VLLMNoOpClient:
     """

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -90,7 +90,7 @@ class GRPOConfig(TrainingArguments):
             timeout, a `ConnectionError` is raised.
         vllm_guided_decoding_regex (`str` or `None`, *optional*, defaults to `None`):
             Regex for vLLM guided decoding. If `None` (default), guided decoding is disabled.
-        vllm_colocation_tp (`int` or `None`, *optional*, defaults to `None`):
+        vllm_colocation (`int` or `None`, *optional*, defaults to `None`):
             Controls colocated vLLM execution and tensor parallelism via the `external_launcher` backend.
             - Set to `None` to disable colocated vLLM entirely.
             - Set to `1` to enable colocated vLLM on each GPU with no tensor parallelism.
@@ -258,7 +258,7 @@ class GRPOConfig(TrainingArguments):
         default=None,
         metadata={"help": "Regex for vLLM guided decoding. If `None` (default), guided decoding is disabled."},
     )
-    vllm_colocation_tp: Optional[int] = field(
+    vllm_colocation: Optional[int] = field(
         default=None,
         metadata={
             "help": (

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -90,14 +90,11 @@ class GRPOConfig(TrainingArguments):
             timeout, a `ConnectionError` is raised.
         vllm_guided_decoding_regex (`str` or `None`, *optional*, defaults to `None`):
             Regex for vLLM guided decoding. If `None` (default), guided decoding is disabled.
-        vllm_colocation (`bool`, *optional*, defaults to `False`):
-            Whether to use colocated vLLM execution via external launcher. If set to `True`, vLLM will be 
-            initialized in **all processes**, each assigned to its respective device. This allows multi-GPU 
-            or multi-node execution with vLLM's external launcher, enabling improved large-scale inference.
-        vllm_tp (`bool`, *optional*, defaults to `False`):
-            Flag to enable tensor parallelism with vLLM using the external_launcher backend. 
-            When set to True, vLLM will be initialized on all processes, with each assigned to its own device. 
-            This enables distributed execution across multiple GPUs or nodes, allowing large-scale inference by splitting the model across devices.
+        vllm_colocation_tp (`int` or `None`, *optional*, defaults to `None`):
+            Controls colocated vLLM execution and tensor parallelism via the `external_launcher` backend.
+            - Set to `None` to disable colocated vLLM entirely.
+            - Set to `1` to enable colocated vLLM on a single GPU with no tensor parallelism.
+            - Set to a value >1 to enable colocated vLLM with tensor parallelism across multiple GPUs or nodes.
 
         > Parameters that control the training
 
@@ -258,21 +255,14 @@ class GRPOConfig(TrainingArguments):
         default=None,
         metadata={"help": "Regex for vLLM guided decoding. If `None` (default), guided decoding is disabled."},
     )
-    vllm_colocation: Optional[bool] = field(
-        default=False,
-        metadata={
-            "help": "Whether to use colocated vLLM execution via external launcher. If set to `True`, vLLM will be "
-                    "initialized in all processes, each assigned to its respective device. This enables optimized "
-                    "multi-GPU inference."
-        },
-    )
-    vllm_tp: Optional[bool] = field(
-        default=False,
+    vllm_colocation_tp: Optional[int] = field(
+        default=None,
         metadata={
             "help": (
-                "Enable tensor parallel execution with vLLM using the external launcher backend. "
-                "When set to `True`, vLLM is initialized on all processes, each bound to its own device. "
-                "This allows efficient distributed inference across multiple GPUs."
+                "Controls colocated vLLM execution and tensor parallelism using the `external_launcher` backend. "
+                "Set to `None` to disable colocated vLLM. "
+                "Set to `1` to enable colocated vLLM on a single device (no tensor parallelism). "
+                "Set to a value >1 to enable colocated vLLM with tensor parallelism across multiple devices."
             )
         },
     )

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -318,6 +318,14 @@ class GRPOConfig(TrainingArguments):
             )
         },
     )
+    vllm_sleep_level1: Optional[bool] = field(
+        default=False,
+        metadata={
+            "help": (
+                "Sleep level 1 enabled - otherwise sleep level 2 default"
+            )
+        },
+    )
 
     # Parameters that control the training
     learning_rate: float = field(

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -95,6 +95,9 @@ class GRPOConfig(TrainingArguments):
             - Set to `None` to disable colocated vLLM entirely.
             - Set to `1` to enable colocated vLLM on each GPU with no tensor parallelism.
             - Set to a value >1 to enable colocated vLLM with tensor parallelism across multiple GPUs.
+        vllm_sleep_enabled (`bool`, *optional*, defaults to `False`):  
+            Indicates whether to enable the sleep operation for vLLM during training.  
+            If set to `True`, vLLM will remain in sleep mode throughout the training stage.
 
         > Parameters that control the training
 
@@ -263,6 +266,16 @@ class GRPOConfig(TrainingArguments):
                 "Set to `None` to disable colocated vLLM. "
                 "Set to `1` to enable colocated vLLM on each device (no tensor parallelism). "
                 "Set to a value >1 to enable colocated vLLM with tensor parallelism across multiple devices."
+            )
+        },
+    )
+    vllm_sleep_enabled: Optional[bool] = field(
+        default=False,
+        metadata={
+            "help": (
+                "Enables sleep mode for colocated vLLM during training. "
+                "Set to `True` to keep vLLM in sleep state during training steps, helping reduce memory usage. "
+                "Set to `False` to disable this behavior."
             )
         },
     )

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -94,6 +94,10 @@ class GRPOConfig(TrainingArguments):
             Whether to use colocated vLLM execution via external launcher. If set to `True`, vLLM will be 
             initialized in **all processes**, each assigned to its respective device. This allows multi-GPU 
             or multi-node execution with vLLM's external launcher, enabling improved large-scale inference.
+        vllm_tp (`bool`, *optional*, defaults to `False`):
+            Flag to enable tensor parallelism with vLLM using the external_launcher backend. 
+            When set to True, vLLM will be initialized on all processes, with each assigned to its own device. 
+            This enables distributed execution across multiple GPUs or nodes, allowing large-scale inference by splitting the model across devices.
 
         > Parameters that control the training
 
@@ -260,6 +264,16 @@ class GRPOConfig(TrainingArguments):
             "help": "Whether to use colocated vLLM execution via external launcher. If set to `True`, vLLM will be "
                     "initialized in all processes, each assigned to its respective device. This enables optimized "
                     "multi-GPU inference."
+        },
+    )
+    vllm_tp: Optional[bool] = field(
+        default=False,
+        metadata={
+            "help": (
+                "Enable tensor parallel execution with vLLM using the external launcher backend. "
+                "When set to `True`, vLLM is initialized on all processes, each bound to its own device. "
+                "This allows efficient distributed inference across multiple GPUs."
+            )
         },
     )
 

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -93,8 +93,8 @@ class GRPOConfig(TrainingArguments):
         vllm_colocation_tp (`int` or `None`, *optional*, defaults to `None`):
             Controls colocated vLLM execution and tensor parallelism via the `external_launcher` backend.
             - Set to `None` to disable colocated vLLM entirely.
-            - Set to `1` to enable colocated vLLM on a single GPU with no tensor parallelism.
-            - Set to a value >1 to enable colocated vLLM with tensor parallelism across multiple GPUs or nodes.
+            - Set to `1` to enable colocated vLLM on each GPU with no tensor parallelism.
+            - Set to a value >1 to enable colocated vLLM with tensor parallelism across multiple GPUs.
 
         > Parameters that control the training
 
@@ -261,7 +261,7 @@ class GRPOConfig(TrainingArguments):
             "help": (
                 "Controls colocated vLLM execution and tensor parallelism using the `external_launcher` backend. "
                 "Set to `None` to disable colocated vLLM. "
-                "Set to `1` to enable colocated vLLM on a single device (no tensor parallelism). "
+                "Set to `1` to enable colocated vLLM on each device (no tensor parallelism). "
                 "Set to a value >1 to enable colocated vLLM with tensor parallelism across multiple devices."
             )
         },

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -308,7 +308,6 @@ class GRPOConfig(TrainingArguments):
             )
         },
     )
-
     vllm_sleep_enabled: Optional[bool] = field(
         default=False,
         metadata={
@@ -316,14 +315,6 @@ class GRPOConfig(TrainingArguments):
                 "Enables sleep mode for colocated vLLM during training. "
                 "Set to `True` to keep vLLM in sleep state during training steps, helping reduce memory usage. "
                 "Set to `False` to disable this behavior."
-            )
-        },
-    )
-    vllm_sleep_level2: Optional[bool] = field(
-        default=False,
-        metadata={
-            "help": (
-                "Sleep level 2 enabled - otherwise sleep level 1"
             )
         },
     )

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -308,6 +308,7 @@ class GRPOConfig(TrainingArguments):
             )
         },
     )
+
     vllm_sleep_enabled: Optional[bool] = field(
         default=False,
         metadata={
@@ -315,6 +316,14 @@ class GRPOConfig(TrainingArguments):
                 "Enables sleep mode for colocated vLLM during training. "
                 "Set to `True` to keep vLLM in sleep state during training steps, helping reduce memory usage. "
                 "Set to `False` to disable this behavior."
+            )
+        },
+    )
+    vllm_sleep_level2: Optional[bool] = field(
+        default=False,
+        metadata={
+            "help": (
+                "Sleep level 2 enabled - otherwise sleep level 1"
             )
         },
     )


### PR DESCRIPTION
# requirements
- git clone https://github.com/huggingface/open-r1.git
- pip install -e open-r1

- pip install vllm==0.7.3
- pip uninstall -y trl
- git clone -b tpcoloc https://github.com/toslali-ibm/trl.git
- pip install -e trl
- cd open-r1


- run experiment (Tp=4 for 4 GPUs for 32B model ` Qwen/Qwen2.5-14B-Instruct`) for vllm coloc tp
```bash
CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 accelerate launch \
    --config_file recipes/accelerate_configs/zero3.yaml \
    --num_processes=8 \
    src/open_r1/grpo.py \
    --config config.yaml
```

See the Config.yaml
```yaml
# Model arguments
model_name_or_path: Qwen/Qwen2.5-14B-Instruct
model_revision: main
torch_dtype: bfloat16
attn_implementation: flash_attention_2

# Data training arguments
dataset_name: open-r1/OpenR1-Math-220k
system_prompt: "You are a helpful AI Assistant that provides well-reasoned and detailed responses. You first think about the reasoning process as an internal monologue and then provide the user with the answer. Respond in the following format: <think>\n...\n</think>\n<answer>\n...\n</answer>"
dataset_prompt_column: "problem"

# GRPO trainer config
bf16: true
use_vllm: true
vllm_tp: true
vllm_gpu_memory_utilization: 0.35
vllm_enable_prefix_caching: false
vllm_max_model_len: 1536

do_eval: false
eval_strategy: "no"
use_vllm: true
do_eval: false
gradient_accumulation_steps: 4
gradient_checkpointing: true
gradient_checkpointing_kwargs:
  use_reentrant: false

learning_rate: 2.0e-05
log_completions: false
log_level: info
logging_first_step: true
logging_steps: 5
logging_strategy: steps
lr_scheduler_type: cosine
max_grad_norm: 0.2
max_prompt_length: 512
max_completion_length: 1024
max_steps: 10
num_generations: 16
num_train_epochs: 1

overwrite_output_dir: true
per_device_train_batch_size: 16

reward_funcs:
- accuracy
- format
reward_weights:
- 1.0
- 1.0
eval_strategy: "no"
save_strategy: "no"
report_to: none

seed: 42
temperature: 0.7
warmup_ratio: 0.1
```